### PR TITLE
DL-2551 - Updated email validation to accept all valid characters

### DIFF
--- a/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/package.scala
+++ b/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/package.scala
@@ -20,6 +20,7 @@ import play.api.data.Forms.{ text, _ }
 import play.api.data.Mapping
 import play.api.data.validation.Constraints.nonEmpty
 import play.api.data.validation.{ Constraint, _ }
+import uk.gov.hmrc.emailaddress.EmailAddress.isValid
 
 package object controllers {
 
@@ -27,7 +28,6 @@ package object controllers {
     private val postcodeWithoutSpacesRegex = "^[A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-Z]{2}$|BFPO[0-9]{1,5}$".r
     private val telephoneNumberRegex = "^[0-9 ]*$"
     private val validStringRegex = "[a-zA-Z0-9,.()\\-\\!@\\s]+"
-    private val emailRegex = """^[a-zA-Z0-9-.]+?@[a-zA-Z0-9-.]+$""".r
     private val nonEmptyPostcode: Constraint[String] = Constraint[String] { fieldValue: String =>
       nonEmpty(errorMessage = "error.postcode.empty")(fieldValue) match {
         case i: Invalid =>
@@ -50,12 +50,8 @@ package object controllers {
       text verifying maxLenWithMsg(maxLength, messageKey)
     }
 
-    private def emailAddress: Constraint[String] = Constraint[String]("constraint.email") { e =>
-      if (e == null) Invalid(ValidationError("error.email"))
-      else if (e.trim.isEmpty) Invalid(ValidationError("error.email"))
-      else emailRegex.findFirstMatchIn(e.trim)
-        .map(_ => Valid)
-        .getOrElse(Invalid("error.email"))
+    private def emailAddress: Constraint[String] = Constraint[String]("constraint.email") { email =>
+      if (isValid(email)) Valid else Invalid("error.email")
     }
 
     private val telephoneNumber: Constraint[String] = Constraint[String]("constraint.required") {

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ lazy val compileDeps = Seq(
   "uk.gov.hmrc" %% "auth-client" % "2.17.0-play-26",
   "uk.gov.hmrc" %% "play-partials" % "6.3.0",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "3.3.0",
-  "uk.gov.hmrc" %% "agent-mtd-identifiers" % "0.12.0"
+  "uk.gov.hmrc" %% "agent-mtd-identifiers" % "0.12.0",
+  "uk.gov.hmrc" %% "emailaddress" % "3.2.0"
 )
 
 def testDeps(scope: String) = Seq(

--- a/test/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/FieldMappingsSpec.scala
+++ b/test/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/FieldMappingsSpec.scala
@@ -131,6 +131,9 @@ class FieldMappingsSpec extends UnitSpec with EitherValues {
       shouldAcceptFieldValue("foo-bar@example.org")
       shouldAcceptFieldValue("fooBar@example.org")
       shouldAcceptFieldValue("1@example.org")
+      shouldAcceptFieldValue("foo!bar@example.org")
+      shouldAcceptFieldValue("foo+bar@example.org")
+      shouldAcceptFieldValue("foo_bar@example.org")
     }
 
     "reject email containing invalid characters" in {
@@ -139,9 +142,6 @@ class FieldMappingsSpec extends UnitSpec with EitherValues {
       shouldRejectFieldValueAsInvalid("foo@")
       shouldRejectFieldValueAsInvalid("@example.org")
       shouldRejectFieldValueAsInvalid("foo,bar@example.org")
-      shouldRejectFieldValueAsInvalid("foo!bar@example.org")
-      shouldRejectFieldValueAsInvalid("foo+bar@example.org")
-      shouldRejectFieldValueAsInvalid("foo_bar@example.org")
     }
   }
 


### PR DESCRIPTION
# DL-2551 - Underscore not allowed in email field OPRA

**Bug fix**

Updated email validation to accept all valid characters.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
