### PR TITLE
DL-2869 - Remove compilation unit test warnings on OPRA-FRONTEND

### DIFF
--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -19,7 +19,7 @@ import javax.inject.{ Inject, Singleton }
 import play.api.i18n._
 import play.api.mvc.Results._
 import play.api.mvc.{ Request, RequestHeader, Result }
-import play.api.{ Configuration, Environment, Mode }
+import play.api.{ Configuration, Environment }
 import uk.gov.hmrc.agentepayeregistrationfrontend.views.html.error_template
 import uk.gov.hmrc.auth.core.{ InsufficientEnrolments, NoActiveSession }
 import uk.gov.hmrc.http.{ JsValidationException, NotFoundException }
@@ -58,7 +58,6 @@ class ErrorHandler @Inject() (
   }
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit request: Request[_]) = {
-    implicit val messagesProvider: MessagesProvider = MessagesImpl(request.lang, messagesApi)
     error_template(
       Messages("global.error.500.title"),
       Messages("global.error.500.heading"),

--- a/app/uk/gov/hmrc/agentepayeregistrationfrontend/connectors/AgentEpayeRegistrationConnector.scala
+++ b/app/uk/gov/hmrc/agentepayeregistrationfrontend/connectors/AgentEpayeRegistrationConnector.scala
@@ -16,24 +16,21 @@
 
 package uk.gov.hmrc.agentepayeregistrationfrontend.connectors
 
-import com.codahale.metrics.MetricRegistry
-import com.kenshoo.play.metrics.Metrics
 import javax.inject.{ Inject, Singleton }
 import play.api.libs.json.JsValue
-import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
 import uk.gov.hmrc.agentepayeregistrationfrontend.config.AppConfig
 import uk.gov.hmrc.agentepayeregistrationfrontend.models.RegistrationRequest
 import uk.gov.hmrc.domain.PayeAgentReference
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
 class AgentEpayeRegistrationConnector @Inject() (
   config: AppConfig,
-  http: DefaultHttpClient) {
+  http: DefaultHttpClient,
+  implicit val ec: ExecutionContext) {
 
   private val registrationUrl = config.opraUrl + "/agent-epaye-registration/registrations"
 

--- a/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/AgentEpayeRegistrationController.scala
+++ b/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/AgentEpayeRegistrationController.scala
@@ -37,7 +37,7 @@ class AgentEpayeRegistrationController @Inject() (
   mcc: MessagesControllerComponents)(implicit config: Configuration) extends FrontendController(mcc) with I18nSupport {
   import AgentEpayeRegistrationController._
 
-  val root: Action[AnyContent] = Action { implicit request =>
+  val root: Action[AnyContent] = Action {
     Redirect(routes.AgentEpayeRegistrationController.start().url)
   }
 

--- a/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/package.scala
+++ b/app/uk/gov/hmrc/agentepayeregistrationfrontend/controllers/package.scala
@@ -55,8 +55,7 @@ package object controllers {
     }
 
     private val telephoneNumber: Constraint[String] = Constraint[String]("constraint.required") {
-      case num => if (num.matches(telephoneNumberRegex)) Valid else Invalid(ValidationError("error.telephone.invalid"))
-      case other => Invalid(ValidationError(other))
+      num => if (num.matches(telephoneNumberRegex)) Valid else Invalid(ValidationError("error.telephone.invalid"))
     }
 
     private def validName(messageKey: String): Constraint[String] = Constraint[String] { fieldValue: String =>

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
-import sbt.Tests.{Group, SubProcess}
+import sbt.Tests.Group
+import uk.gov.hmrc.{ForkedJvmPerTestSettings, SbtAutoBuildPlugin}
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
-import uk.gov.hmrc.SbtAutoBuildPlugin
-import uk.gov.hmrc.ForkedJvmPerTestSettings
 
 lazy val scoverageSettings = {
   import scoverage.ScoverageKeys
@@ -17,10 +16,10 @@ lazy val scoverageSettings = {
 
 lazy val compileDeps = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
-  "uk.gov.hmrc" %% "govuk-template" % "5.48.0-play-26",
-  "uk.gov.hmrc" %% "play-ui" % "8.7.0-play-26",
-  "uk.gov.hmrc" %% "auth-client" % "2.32.2-play-26",
+  "uk.gov.hmrc" %% "bootstrap-play-26" % "1.5.0",
+  "uk.gov.hmrc" %% "govuk-template" % "5.52.0-play-26",
+  "uk.gov.hmrc" %% "play-ui" % "8.8.0-play-26",
+  "uk.gov.hmrc" %% "auth-client" % "2.35.0-play-26",
   "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "4.0.0",
   "uk.gov.hmrc" %% "agent-mtd-identifiers" % "0.17.0-play-26",
@@ -30,9 +29,9 @@ lazy val compileDeps = Seq(
 def testDeps(scope: String) = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
   "org.scalatest" %% "scalatest" % "3.0.8" % scope,
-  "org.mockito" % "mockito-core" % "3.2.4" % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % scope,
-  "com.github.tomakehurst" % "wiremock" % "2.26.0" % scope
+  "org.mockito" % "mockito-core" % "3.3.3" % scope,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % scope,
+  "com.github.tomakehurst" % "wiremock" % "2.26.3" % scope
 )
 
 val jettyVersion = "9.2.24.v20180105"
@@ -41,7 +40,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "agent-epaye-registration-frontend",
     organization := "uk.gov.hmrc",
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.11",
     PlayKeys.playDefaultPort := 9446,
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
@@ -68,7 +67,12 @@ lazy val root = (project in file("."))
     ),
     publishingSettings,
     scoverageSettings,
-    unmanagedResourceDirectories in Compile += baseDirectory.value / "resources"
+    unmanagedResourceDirectories in Compile += baseDirectory.value / "resources",
+    scalacOptions += "-P:silencer:pathFilters=views;routes",
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full
+    ),
   )
   .configs(IntegrationTest)
   .settings(

--- a/it/uk/gov/hmrc/agentepayeregistrationfrontend/connectors/AgentEpayeRegistrationConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentepayeregistrationfrontend/connectors/AgentEpayeRegistrationConnectorISpec.scala
@@ -1,7 +1,7 @@
 package uk.gov.hmrc.agentepayeregistrationfrontend.connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.http.Status
@@ -15,6 +15,8 @@ import uk.gov.hmrc.http.{ BadGatewayException, BadRequestException, HeaderCarrie
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 import uk.gov.hmrc.play.test.UnitSpec
 
+import scala.concurrent.ExecutionContext
+
 class AgentEpayeRegistrationConnectorISpec extends UnitSpec with GuiceOneAppPerSuite with WireMockSupport with MockitoSugar {
 
   override implicit lazy val app: Application = appBuilder.build()
@@ -27,7 +29,8 @@ class AgentEpayeRegistrationConnectorISpec extends UnitSpec with GuiceOneAppPerS
   private implicit val hc = HeaderCarrier()
 
   private lazy val connector: AgentEpayeRegistrationConnector =
-    new AgentEpayeRegistrationConnector(app.injector.instanceOf[AppConfig], app.injector.instanceOf[DefaultHttpClient])
+    new AgentEpayeRegistrationConnector(app.injector.instanceOf[AppConfig], app.injector.instanceOf[DefaultHttpClient],
+      app.injector.instanceOf[ExecutionContext])
 
   private val address = Address("29 Acacia Road", "Nuttytown", Some("Bannastate"), Some("Country"), "AA11AA")
   private val regRequest = RegistrationRequest(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
   "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
@@ -16,4 +16,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")

--- a/test/ErrorHandlerSpec.scala
+++ b/test/ErrorHandlerSpec.scala
@@ -15,7 +15,7 @@
  */
 
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{ Lang, MessagesApi }


### PR DESCRIPTION
# DL-2869 - Remove compilation unit test warnings on OPRA-FRONTEND

Removed all compilation, unit test and integration test warnings.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
