### PR TITLE
DL-2869 - disabled JUnitXmlReportPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,5 +84,6 @@ lazy val root = (project in file("."))
   )
   .settings(scalariformItSettings, majorVersion := 0)
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .disablePlugins(JUnitXmlReportPlugin)
 
 def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = ForkedJvmPerTestSettings.oneForkedJvmPerTest(tests)


### PR DESCRIPTION
# DL-2869 - Remove compilation unit test warnings on OPRA-FRONTEND

`JUnitXmlReportPlugin` is causing Jenkins to label builds as unstable, this PR disables it.