### PR TITLE
DL-6545 - Added character validation to agent/contact name

### DIFF
--- a/app/forms/YourAgentNameFormProvider.scala
+++ b/app/forms/YourAgentNameFormProvider.scala
@@ -30,7 +30,8 @@ class YourAgentNameFormProvider @Inject() extends Mappings {
       "value" -> text("enterYourAgentName.error.required").verifying(
         maxLength(
           maxLength, "enterYourAgentName.error.length"
-        )
+        ),
+        validCharacters("enterYourAgentName.error.invalidCharacters")
       )
     )
 }

--- a/app/forms/YourContactDetailsFormProvider.scala
+++ b/app/forms/YourContactDetailsFormProvider.scala
@@ -32,7 +32,8 @@ class YourContactDetailsFormProvider @Inject() extends Mappings {
       "contactName" -> text("yourContactDetails.contactName.error.required").verifying(
         maxLength(
           contactNameMaxLength, "yourContactDetails.contactName.error.length"
-        )
+        ),
+        validCharacters("yourContactDetails.contactName.error.invalidCharacters")
       ),
       "emailAddress" ->
         optional(

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -22,6 +22,8 @@ import java.time.LocalDate
 
 trait Constraints {
 
+  private val validCharactersPattern = "[a-zA-Z0-9,.()\\-\\!@\\s]+"
+
   protected def firstError[A](constraints: Constraint[A]*): Constraint[A] =
     Constraint {
       input =>
@@ -77,6 +79,8 @@ trait Constraints {
       case _ =>
         Invalid(errorKey, regex)
     }
+
+  protected def validCharacters(errorKey: String): Constraint[String] = regexp(validCharactersPattern, errorKey)
 
   protected def maxLength(maximum: Int, errorKey: String): Constraint[String] =
     Constraint {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -67,7 +67,8 @@ enterYourAgentName.heading = Agent name
 enterYourAgentName.hint=This could be your agency name, payroll bureau name, or your own name if you are acting as an individual.
 enterYourAgentName.checkYourAnswersLabel = Enter your agent name
 enterYourAgentName.error.required = Enter your agent name
-enterYourAgentName.error.length = Agent name must be 100 characters or less
+enterYourAgentName.error.length = Agent name must be 56 characters or less
+enterYourAgentName.error.invalidCharacters = Agent name must only include letters a to z, numbers, commas, full stops, round brackets, hyphens, exclamation marks, @ signs and spaces
 enterYourAgentName.change.hidden = EnterYourAgentName
 
 yourContactDetails.title = Enter your contact details
@@ -76,7 +77,8 @@ yourContactDetails.info = HMRC will treat this as your main contact for PAYE for
 
 yourContactDetails.contactName.heading = Contact name
 yourContactDetails.contactName.error.required = Enter a contact name
-yourContactDetails.contactName.error.length = Contact name must be 100 characters or less
+yourContactDetails.contactName.error.length = Contact name must be 56 characters or less
+yourContactDetails.contactName.error.invalidCharacters = Contact name must only include letters a to z, numbers, commas, full stops, round brackets, hyphens, exclamation marks, @ signs and spaces
 yourContactDetails.emailAddress.heading = Email address (optional)
 yourContactDetails.emailAddress.error.invalid = Enter a valid email address, like name@example.com
 yourContactDetails.emailAddress.error.length = Email address must be 129 characters or less

--- a/test/forms/FormSpec.scala
+++ b/test/forms/FormSpec.scala
@@ -39,4 +39,5 @@ trait FormSpec extends AnyFreeSpec with Matchers with OptionValues {
   def error(key: String, value: String, args: Any*) = Seq(FormError(key, value, args))
 
   lazy val emptyForm = Map[String, String]()
+  lazy val validCharacterRegex = "[a-zA-Z0-9,.()\\-\\!@\\s]+"
 }

--- a/test/forms/YourAgentNameFormProviderSpec.scala
+++ b/test/forms/YourAgentNameFormProviderSpec.scala
@@ -23,6 +23,7 @@ class YourAgentNameFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "enterYourAgentName.error.required"
   val lengthKey = "enterYourAgentName.error.length"
+  val invalidCharactersKey = "enterYourAgentName.error.invalidCharacters"
   val maxLength = 56
 
   val form = new YourAgentNameFormProvider()()
@@ -42,6 +43,13 @@ class YourAgentNameFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      fieldName,
+      "This & That / Ltd",
+      error = FormError(fieldName, invalidCharactersKey, Seq(validCharacterRegex))
     )
 
     behave like mandatoryField(

--- a/test/forms/YourContactDetailsFormProviderSpec.scala
+++ b/test/forms/YourContactDetailsFormProviderSpec.scala
@@ -26,6 +26,7 @@ class YourContactDetailsFormProviderSpec extends StringFieldBehaviours with Emai
   ".contactName" - {
     val requiredKey = "yourContactDetails.contactName.error.required"
     val lengthKey = "yourContactDetails.contactName.error.length"
+    val invalidCharacterKey = "yourContactDetails.contactName.error.invalidCharacters"
     val maxLength = 56
 
     val fieldName = "contactName"
@@ -41,6 +42,13 @@ class YourContactDetailsFormProviderSpec extends StringFieldBehaviours with Emai
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like fieldWithRegex(
+      form,
+      fieldName,
+      "This & That / Ltd",
+      error = FormError(fieldName, invalidCharacterKey, Seq(validCharacterRegex))
     )
 
     behave like mandatoryField(

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -87,13 +87,13 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {
       length <- choose(1, maxLength)
-      chars <- listOfN(length, arbitrary[Char])
+      chars <- listOfN(length, alphaChar)
     } yield chars.mkString
 
   def stringsLongerThan(minLength: Int): Gen[String] = for {
     maxLength <- (minLength * 2).max(100)
     length    <- Gen.chooseNum(minLength + 1, maxLength)
-    chars     <- listOfN(length, arbitrary[Char])
+    chars     <- listOfN(length, alphaChar)
   } yield chars.mkString
 
   def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =


### PR DESCRIPTION
Added validation to the Agent name/ Contact name fields. Also amended length error message for these fields (it allows a max of 56 chars, but error message said 100)